### PR TITLE
feat: enable asserts when running dart_frog dev

### DIFF
--- a/packages/dart_frog_cli/lib/src/dev_server_runner/dev_server_runner.dart
+++ b/packages/dart_frog_cli/lib/src/dev_server_runner/dev_server_runner.dart
@@ -153,12 +153,16 @@ class DevServerRunner {
       final enableVmServiceFlag = '--enable-vm-service=$dartVmServicePort';
 
       logger.detail(
-        '''[process] dart $enableVmServiceFlag ${path.join('.dart_frog', 'server.dart')}''',
+        '''[process] dart $enableVmServiceFlag --enable-asserts ${path.join('.dart_frog', 'server.dart')}''',
       );
 
       final process = await _startProcess(
         'dart',
-        [enableVmServiceFlag, path.join('.dart_frog', 'server.dart')],
+        [
+          enableVmServiceFlag,
+          '--enable-asserts',
+          path.join('.dart_frog', 'server.dart')
+        ],
         runInShell: true,
       );
 


### PR DESCRIPTION
## Status

**READY*

## Description

Enable asserts usage when running the server in dev mode. This is useful when dealing with packages that provides certain features at development time, like Isar Database Inspector ([Isar](https://pub.dev/packages/isar)) or Development Filter ([Logger](https://pub.dev/packages/logger)), which executes functions like the example below to guarantee that these features will be executed only in development builds:

```dart
// Tree shake the inspector for profile and release builds.
assert(() {
   // Do your things....

    return true;
}());
```

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
